### PR TITLE
Allows to subcommands to execute without argument.

### DIFF
--- a/operetta.js
+++ b/operetta.js
@@ -71,7 +71,7 @@ util.inherits(Operetta, events.EventEmitter);
 
 Operetta.prototype.start = function(callback) {
   var operetta = this;
-  if (operetta.parent && operetta.args.length == 0) operetta.usage();
+  if (operetta.parent && operetta.args.length == 0 && operetta.noop == false) operetta.usage();
   else {
     if (!operetta.opts["-h"]) {
       operetta.options(['-h','--help'], "Show Help", function() {


### PR DESCRIPTION
I want the subcommand to execute without parameter...with predefined defaults.

now I can provide....

```
operetta.noop = true
```

and my subcommands dont trigger usage().
